### PR TITLE
Normalization first pass

### DIFF
--- a/nari/cli/client.py
+++ b/nari/cli/client.py
@@ -29,7 +29,7 @@ def handle_args(log=None, verbose=False, error=False) -> None:
 
     # We only really do ACT Network logs for now, so no need to do fancy file detection or anything like that
     reader = ActLogReader(log, raise_on_invalid_id=error)
-    for event in reader.read():
+    for event in reader:
         print(event)
 
 

--- a/nari/cli/client.py
+++ b/nari/cli/client.py
@@ -42,12 +42,12 @@ def parse_fights(reader: Reader) -> List[List[str]]:
                 fight_log.append(current_fight)
             current_fight = {
                 'date': event.timestamp,
-                'name': hex(event.instance_id),
+                'name': str(event.instance_id),
             }
         elif command in (DirectorUpdateCommand.fadeout, DirectorUpdateCommand.clear): # naive, but functional?
             current_fight['fights'] = current_fight.get('fights', 0) + 1
 
-    column_headers = ['date', 'instance id', 'fights']
+    column_headers = ['date', 'instance id', 'encounters']
     matrix = [column_headers]
 
     for fight in fight_log:

--- a/nari/cli/client.py
+++ b/nari/cli/client.py
@@ -3,11 +3,63 @@
 
 from argparse import ArgumentParser, Namespace
 from logging import basicConfig, getLogger, Logger, CRITICAL, INFO
+from typing import List
 
 from nari.io.actlog import ActLogReader
+from nari.io.reader import Reader
+from nari.parser.normaliser import Normaliser
+from nari.types.event import Type as EventType
+from nari.types.event.directorupdate import DirectorUpdateCommand
 
 DEFAULT_LOG_FORMAT: str = '[%(levelname)s] %(message)s'
 logger: Logger = getLogger('nari')
+
+
+def print_matrix(matrix: List[List[str]]):
+    """Hacky function to print out an 'aligned' set of data"""
+    col_width = max(len(word) for row in matrix for word in row) + 2
+    for row in matrix:
+        print(''.join(word.ljust(col_width) for word in row))
+
+
+
+def parse_fights(reader: Reader) -> List[List[str]]:
+    """Takes in a reader object and parses the fight details out of it"""
+    class DirectorFilter(Normaliser):
+        """Literally only filters out director updates"""
+        def on_event(self, event):
+            if event.id == EventType.directorupdate:
+                return event
+            return None
+
+    fight_log: List[dict] = []
+    current_fight: dict = {}
+
+    for event in DirectorFilter(reader):
+        command = event.director_command
+        if command == DirectorUpdateCommand.init:
+            if current_fight:
+                fight_log.append(current_fight)
+            current_fight = {
+                'date': event.timestamp,
+                'name': hex(event.instance_id),
+            }
+        elif command in (DirectorUpdateCommand.fadeout, DirectorUpdateCommand.clear): # naive, but functional?
+            current_fight['fights'] = current_fight.get('fights', 0) + 1
+
+    column_headers = ['date', 'instance id', 'fights']
+    matrix = [column_headers]
+
+    for fight in fight_log:
+        num_fights = fight.get('fights', 0)
+        amtstr = 'fight' if num_fights == 1 else 'fights'
+        matrix.append([
+            f'[{fight["date"]}]',
+            fight['name'],
+            f'{num_fights} {amtstr}',
+        ])
+
+    return matrix
 
 
 def create_parser() -> ArgumentParser:
@@ -29,8 +81,8 @@ def handle_args(log=None, verbose=False, error=False) -> None:
 
     # We only really do ACT Network logs for now, so no need to do fancy file detection or anything like that
     reader = ActLogReader(log, raise_on_invalid_id=error)
-    for event in reader:
-        print(event)
+    data = parse_fights(reader)
+    print_matrix(data)
 
 
 def main():

--- a/nari/io/actlog.py
+++ b/nari/io/actlog.py
@@ -1,5 +1,5 @@
 """Classes and functions for handling network logs from ACT"""
-from typing import List
+from typing import Union
 
 from nari.io.reader import Reader
 from nari.types.event import Type as EventType
@@ -45,8 +45,9 @@ class ActLogReader(Reader):
         return event
 
 
-    def read(self) -> List[Event]:
+    def read_next(self) -> Union[Event, None]:
         """Returns an array of all the act log events from the file"""
-        for line in self.handle:
-            yield self.handle_line(line)
-        # return [self.handle_line(line) for line in self.handle]
+        line: str = self.handle.readline()
+        if len(line) == 0:
+            return None
+        return self.handle_line(line)

--- a/nari/io/reader.py
+++ b/nari/io/reader.py
@@ -1,13 +1,26 @@
 """Collection of reading-related classes and utilities"""
 
 from abc import ABCMeta, abstractmethod
-from typing import List
+from typing import List, Iterable, Union
 
 from nari.types.event.base import Event
 
-# pylint: disable=too-few-public-methods
+
 class Reader(metaclass=ABCMeta):
     """Represents an abstract base for reader objects"""
+    def __iter__(self) -> Iterable[Event]:
+        return self
+
+    def __next__(self) -> Event:
+        event: Event = self.read_next()
+        if event:
+            return event
+        raise StopIteration
+
     @abstractmethod
-    def read(self) -> List[Event]:
-        """Implementing classes must implement this method to return a list of events"""
+    def read_next(self) -> Union[Event, None]:
+        """Implementing classes must implement this method to return the next parsed event"""
+
+    def read_all(self) -> List[Event]:
+        """Iterates through all events and returns them as a list"""
+        return list(self)

--- a/nari/parser/__init__.py
+++ b/nari/parser/__init__.py
@@ -1,0 +1,1 @@
+"""This sub-module deals with code that's transformative to the event array"""

--- a/nari/parser/normaliser.py
+++ b/nari/parser/normaliser.py
@@ -6,7 +6,7 @@ from typing import Union, List, Iterable, Iterator
 from nari.types.event.base import Event
 
 
-class Normalizer(metaclass=ABCMeta):
+class Normaliser(metaclass=ABCMeta):
     """Normalizers take in interable events and spit out iterable events"""
     def __init__(self, stream: Iterator[Event]):
         self.stream = iter(stream)
@@ -63,19 +63,3 @@ class Normalizer(metaclass=ABCMeta):
         event that it recieves; conversely you could fabricate entirely new events to place
         in the resultant array.
         """
-
-
-class PassthroughNormalizer(Normalizer):
-    """Dumb way of passing through events to act like you're cool or something"""
-    def on_event(self, event):
-        return event
-
-class DoubleNormalizer(Normalizer):
-    """Even dumber thing to return a duplicate of every event like you're dumb or something"""
-    def on_event(self, event):
-        return [event, event]
-
-class BigotNormalizer(Normalizer):
-    """Bigoted normalizer - let's nothing through because it isn't as good as it"""
-    def on_event(self, event):
-        return None

--- a/nari/parser/normaliser.py
+++ b/nari/parser/normaliser.py
@@ -1,4 +1,4 @@
-"""Provides the Normalizer abstract base class"""
+"""Provides the Normaliser abstract base class"""
 
 from abc import ABCMeta, abstractmethod
 from typing import Union, List, Iterable, Iterator
@@ -7,7 +7,7 @@ from nari.types.event.base import Event
 
 
 class Normaliser(metaclass=ABCMeta):
-    """Normalizers take in interable events and spit out iterable events"""
+    """Normalisers take in interable events and spit out iterable events"""
     def __init__(self, stream: Iterator[Event]):
         self.stream = iter(stream)
         self.buffer: List[Event] = []
@@ -59,7 +59,7 @@ class Normaliser(metaclass=ABCMeta):
     def on_event(self, event: Event) -> Union[List[Event], Event]:
         """Takes an event and returns either a single event in turn, or a list of events
 
-        A normalizer that does nothing would just implement the method to return the same
-        event that it recieves; conversely you could fabricate entirely new events to place
+        A normaliser that does nothing would just implement the method to return the same
+        event that it receives; conversely you could fabricate entirely new events to place
         in the resultant array.
         """

--- a/nari/parser/normalizer.py
+++ b/nari/parser/normalizer.py
@@ -1,0 +1,66 @@
+"""Provides the Normalizer abstract base class"""
+
+from abc import ABCMeta, abstractmethod
+from typing import Union, List, Iterable, Iterator
+
+from nari.types.event.base import Event
+
+
+class Normalizer(metaclass=ABCMeta):
+    """Normalizers take in interable events and spit out iterable events"""
+    def __init__(self, stream: Iterator[Event]):
+        self.stream = iter(stream)
+        self.buffer: List[Event] = []
+        self.stream_finished = False
+
+    def __iter__(self) -> Iterable[Event]:
+        return self
+
+    def __next__(self) -> Event:
+        event: Event = self.handle_next()
+        if event:
+            return event
+        raise StopIteration
+
+    def handle_next(self) -> Union[Event, None]:
+        """Handles the next event from the input stream, calling `on_event()` with each event"""
+        if not self.stream_finished:
+            # try to keep grabbing at least one event and process it into the buffer
+            try:
+                new_event = next(self.stream)
+                handled_event = self.on_event(new_event)
+
+                if isinstance(handled_event, list):
+                    self.buffer.extend(handled_event)
+                elif isinstance(handled_event, Event):
+                    self.buffer.append(handled_event)
+                else: # not a list or an Event?
+                    raise Exception('yell at nono to come up with a name for this screwup')
+            except StopIteration:
+                self.stream_finished = True
+
+        # keep dumping that buffer
+        if len(self.buffer) > 0:
+            return self.buffer.pop(0)
+
+        return None
+
+    @abstractmethod
+    def on_event(self, event: Event) -> Union[List[Event], Event]:
+        """Takes an event and returns either a single event in turn, or a list of events
+
+        A normalizer that does nothing would just implement the method to return the same
+        event that it recieves; conversely you could fabricate entirely new events to place
+        in the resultant array.
+        """
+
+
+class PassthroughNormalizer(Normalizer):
+    """Dumb way of passing through events to act like you're cool or something"""
+    def on_event(self, event):
+        return event
+
+class DoubleNormalizer(Normalizer):
+    """Even dumber thing to return a duplicate of every event like you're dumb or something"""
+    def on_event(self, event):
+        return [event, event]

--- a/nari/types/event/base.py
+++ b/nari/types/event/base.py
@@ -8,7 +8,7 @@ class Event():
     """Represents a base event"""
     __id__: int = -1
 
-    def __init__(self, timestamp: datetime, *, params: List[str] = None, index: int = 0, checksum: str = '', id_: int = None):
+    def __init__(self, timestamp: datetime, *, params: List[str] = [], index: int = 0, checksum: str = '', id_: int = None): # pylint: disable=dangerous-default-value
         self.id = id_ or self.__id__
         self.timestamp = timestamp
         self.params = params

--- a/nari/types/event/base.py
+++ b/nari/types/event/base.py
@@ -2,13 +2,13 @@
 
 from datetime import datetime
 from hashlib import md5
-from typing import List
+from typing import List, Union
 
 class Event():
     """Represents a base event"""
     __id__: int = -1
 
-    def __init__(self, timestamp: datetime, *, params: List[str] = [], index: int = 0, checksum: str = '', id_: int = None): # pylint: disable=dangerous-default-value
+    def __init__(self, timestamp: Union[datetime, str], *, params: List[str] = [], index: int = 0, checksum: str = '', id_: int = None): # pylint: disable=dangerous-default-value
         self.id = id_ or self.__id__
         self.timestamp = timestamp
         self.params = params

--- a/nari/types/event/directorupdate.py
+++ b/nari/types/event/directorupdate.py
@@ -150,7 +150,15 @@ class DirectorUpdateCommand(IntEnum):
     """
     barrierup = 0x40000012
     """Puts an 'instance' barrier up"""
+    instancesynctime = 0x80000002
+    """A periodic packet sent to indicate the remaining time in an instance
 
+    Params that follow the command:
+    | Index | Description            |
+    | ----: | ---------------------: |
+    | 3     | Time left (in seconds) |
+    | 4-6   | Unused                 |
+    """
     @classmethod
     def name_for_value(cls, value):
         """Helper class method to return the name of the enum when you already have the value"""

--- a/nari/types/event/zonechange.py
+++ b/nari/types/event/zonechange.py
@@ -6,5 +6,8 @@ from nari.types.event import Type
 class ZoneChange(Event):
     """ZoneChange"""
     __id__ = Type.zonechange.value
+    def handle_params(self):
+        self.zone_id = int(self.params[0], 16)
+        self.zone_name = self.params[1]
     def __repr__(self):
-        return f'<ZoneChange ({self.params[1]})>'
+        return f'<ZoneChange ({self.zone_name})>'


### PR DESCRIPTION
A first normalization pass. In particular, this does a number of things:

* Focuses more on 'streams' of data by changing the Reader abstract base into an iterator under the hood – by overriding the `read_next` method, the class handles the rest of it being iterable. This enables some nice scenarios where iterating through pre-created lists of events or a reader is functionally the same code
* In keeping with this 'streams' design, there's now an abstract `Normaliser` class that takes a List of iterable of Events and processes them allowing you to do a normalization pass. **Note**: I have found that Act-based logs do not always write their events to a file in the correct order, so there may be a need for a `TimeOrder` normalizer or some such.
* I updated the cli frontend to provide a more generic view of the log, since I assume the cli might be used for exploring fight-based metrics by default:

```
$ nari ~/Projects/nari-playground/Network_20510_20200518.log
date                                 instance id                          encounters                           
[2020-05-18T18:28:13.2190000-05:00]  30091                                2 fights                             
[2020-05-18T20:09:13.4080000-05:00]  30095                                8 fights                             
[2020-05-18T20:46:11.0580000-05:00]  30089                                7 fights                             
[2020-05-19T19:52:03.1960000-05:00]  30089                                3 fights                             
[2020-05-19T20:20:22.0740000-05:00]  30091                                3 fights                             
[2020-05-19T20:39:59.7940000-05:00]  30093                                7 fights                             
[2020-05-19T21:38:28.1170000-05:00]  30093                                0 fights                             
[2020-05-19T21:40:21.2030000-05:00]  30093                                2 fights                             
[2020-05-19T22:04:38.7530000-05:00]  74                                   1 fight                              
[2020-05-19T22:24:40.2730000-05:00]  30062                                1 fight                              
[2020-05-20T20:27:50.9200000-05:00]  30056                                1 fight                              
[2020-05-20T20:40:26.2610000-05:00]  30056                                1 fight                              
[2020-05-20T20:52:49.0420000-05:00]  30065                                1 fight                              
[2020-05-20T21:01:31.1840000-05:00]  30066                                4 fights                             
[2020-05-20T21:22:43.1580000-05:00]  20007                                1 fight                              
[2020-05-20T21:27:37.1280000-05:00]  30063                                1 fight                              
[2020-05-20T21:34:52.4110000-05:00]  73                                   1 fight                              
[2020-05-20T21:51:07.1720000-05:00]  30023                                1 fight                              
[2020-05-20T21:57:03.5920000-05:00]  20033                                1 fight                              
[2020-05-21T22:31:24.0200000-05:00]  73                                   1 fight                              
```

(for reference, a 161 MB log file that has several days of act data in it seems to take ~3.8s to process with almost no overhead from the normalization pass)