### PR TITLE
Update NetworkTargetHeadMarker docs for known param details

### DIFF
--- a/nari/types/event/directorupdate.py
+++ b/nari/types/event/directorupdate.py
@@ -166,6 +166,7 @@ class DirectorUpdateCommand(IntEnum):
     """A periodic packet sent to indicate the remaining time in an instance
 
     Params that follow the command:
+
     | Index | Description            |
     | ----: | ---------------------: |
     | 3     | Time left (in seconds) |

--- a/nari/types/event/networktargetheadmarker.py
+++ b/nari/types/event/networktargetheadmarker.py
@@ -5,17 +5,17 @@ from nari.types.actor import Actor
 from nari.types.event import Type
 
 class NetworkTargetHeadMarker(Event):
-    """Looks like it identifies the type of marker over someone's head iunno"""
+    """Sets the model to use for the marker over a player's head"""
     __id__ = Type.networktargetheadmarker.value
     def handle_params(self):
         self.target_actor = Actor(self.params[0], self.params[1])
         # there's 6 other bytes afterwards:
-        # params[2]: dunno
-        # params[3]: dunno
-        # params[4]: I think this is the type of marker
-        # params[5]: dunno
-        # params[6]: dunno
-        # params[7]: dunno
+        # params[2]: junk, literally padding from the Message IPC header
+        # params[3]: padding
+        # params[4]: model ID
+        # params[5]: unused
+        # params[6]: unused
+        # params[7]: unused
 
     def __repr__(self):
         return f'<HeadMarker ({self.target_actor})>'


### PR DESCRIPTION
I honestly have no idea why this uses the padding at the end of an IPC's GameEvent segment header, but it do.