### PR TITLE
Analyzer first pass

### DIFF
--- a/nari/cli/client.py
+++ b/nari/cli/client.py
@@ -24,13 +24,11 @@ def print_matrix(matrix: List[List[str]]):
 def parse_fights(reader: Reader) -> List[List[str]]:
     """Takes in a reader object and parses the fight details out of it"""
     fight_list = FightList(reader)
-    fight_list.process_events()
-
-    return fight_list.results()
+    return fight_list.process_events()
 
 
 def create_parser() -> ArgumentParser:
-    """Convienience function to create the argument parser"""
+    """Convenience function to create the argument parser"""
     parser: ArgumentParser = ArgumentParser()
     parser.add_argument('log', help='Path to an ACT .log file')
     parser.add_argument('-v', '--verbose', action='store_true')

--- a/nari/cli/fightlist.py
+++ b/nari/cli/fightlist.py
@@ -1,0 +1,46 @@
+"""Helper classes for parsing out fights from event data"""
+
+from typing import List
+
+from nari.parser.analyser import Analyser
+from nari.types.event import Type as EventType
+from nari.types.event.base import Event
+from nari.types.event.directorupdate import DirectorUpdate, DirectorUpdateCommand
+
+
+class FightList(Analyser):
+    """Takes a stream of (filtered) DirectorUpdate events and parses them into an array of fights"""
+    # pylint: disable=attribute-defined-outside-init
+    def init(self):
+        column_headers: List[str] = ['date', 'instance id', 'encounters']
+        self.matrix = [column_headers]
+        self.fight_log: List[dict] = []
+        self.current_fight: dict = {}
+        self.add_event_hook(filter_fn=lambda e: e.id == EventType.directorupdate, callback=self.fight_event)
+
+    def fight_event(self, event: Event):
+        """For each fight event, figure out stuff"""
+        # safety check
+        if not isinstance(event, DirectorUpdate):
+            return
+        command = event.director_command
+        if command == DirectorUpdateCommand.init:
+            if self.current_fight:
+                self.fight_log.append(self.current_fight)
+            self.current_fight = {
+                'date': event.timestamp,
+                'name': str(event.instance_id),
+            }
+        elif command in (DirectorUpdateCommand.fadeout, DirectorUpdateCommand.clear): # naive, but functional?
+            self.current_fight['fights'] = self.current_fight.get('fights', 0) + 1
+
+    def results(self):
+        for fight in self.fight_log:
+            num_fights = fight.get('fights', 0)
+            amtstr = 'fight' if num_fights == 1 else 'fights'
+            self.matrix.append([
+                f'[{fight["date"]}',
+                fight['name'],
+                f'{num_fights} {amtstr}'
+            ])
+        return self.matrix

--- a/nari/cli/fightlist.py
+++ b/nari/cli/fightlist.py
@@ -16,7 +16,7 @@ class FightList(Analyser):
         self.matrix = [column_headers]
         self.fight_log: List[dict] = []
         self.current_fight: dict = {}
-        self.add_event_hook(filter_fn=lambda e: e.id == EventType.directorupdate, callback=self.fight_event)
+        self.add_event_hook(predicate=lambda e: e.id == EventType.directorupdate, callback=self.fight_event)
         self.add_topic_hook(AnalyserTopic.stream_end, callback=self.complete)
 
     def fight_event(self, event: Event):

--- a/nari/parser/analyser.py
+++ b/nari/parser/analyser.py
@@ -29,10 +29,10 @@ class Analyser():
     def init(self):
         """Subclasses override this method to set up for their particular use case"""
 
-    def add_event_hook(self, filter_fn: FilterFunc, callback: CallbackFunc) -> int:
+    def add_event_hook(self, predicate: FilterFunc, callback: CallbackFunc) -> int:
         """Adds an event hook that watches for certain types of events and calls a callback function on them"""
-        filter_id = id(filter_fn)
-        self.hooks[filter_id] = (filter_fn, callback)
+        filter_id = id(predicate)
+        self.hooks[filter_id] = (predicate, callback)
         return filter_id
 
     def add_topic_hook(self, topic: AnalyserTopic, callback: TopicCallbackFunc):
@@ -60,4 +60,4 @@ class Analyser():
         return self.results()
 
     def results(self) -> Any:
-        """Override to provide results from your analyzer. It's up to you to return what you want"""
+        """Override to provide results from your analyser. It's up to you to return what you want"""

--- a/nari/parser/analyser.py
+++ b/nari/parser/analyser.py
@@ -1,19 +1,29 @@
 """Analysers parse streams of data like Normalisers and Writers, but don't push out an event stream"""
 
-from typing import Iterable, Iterator, Callable, Tuple, Dict, Any
+from enum import IntEnum, auto
+from typing import Iterable, Iterator, Callable, Tuple, Dict, Any, List
 from nari.types.event.base import Event
 
 # some useful typedefs
 FilterFunc = Callable[[Event], bool]
 CallbackFunc = Callable[[Event], None]
+TopicCallbackFunc = Callable[[], None]
 FilterCallbackBundle = Tuple[FilterFunc, CallbackFunc]
 Hooks = Dict[int, FilterCallbackBundle]
+Topics = Dict[int, List[TopicCallbackFunc]]
+
+
+class AnalyserTopic(IntEnum):
+    """List of topics"""
+    stream_end = auto()
+
 
 class Analyser():
     """Analyser base class"""
     def __init__(self, stream: Iterable[Event]):
         self.stream: Iterator[Event] = iter(stream)
         self.hooks: Hooks = {}
+        self.topics: Topics = {}
         self.init()
 
     def init(self):
@@ -25,16 +35,27 @@ class Analyser():
         self.hooks[filter_id] = (filter_fn, callback)
         return filter_id
 
+    def add_topic_hook(self, topic: AnalyserTopic, callback: TopicCallbackFunc):
+        """Adds a set of 'topic hooks' that run at specified times"""
+        topics = self.topics.get(topic, [])
+        topics.append(callback)
+        self.topics[topic] = topics
+
     def remove_event_hook(self, filter_id: int):
         """Removes an event hook"""
         del self.hooks[filter_id]
 
     def process_events(self):
         """The 'main' loop. Grabs every event, and calls all relevant callback functions on them"""
+        # process the main stream
         for event in self.stream:
             for filter_fn, callback in self.hooks.values():
                 if filter_fn(event):
                     callback(event)
+
+        # call the 'stream_end' topic
+        for callback in self.topics.get(AnalyserTopic.stream_end, []):
+            callback()
 
         return self.results()
 

--- a/nari/parser/analyser.py
+++ b/nari/parser/analyser.py
@@ -1,0 +1,42 @@
+"""Analysers parse streams of data like Normalisers and Writers, but don't push out an event stream"""
+
+from typing import Iterable, Iterator, Callable, Tuple, Dict, Any
+from nari.types.event.base import Event
+
+# some useful typedefs
+FilterFunc = Callable[[Event], bool]
+CallbackFunc = Callable[[Event], None]
+FilterCallbackBundle = Tuple[FilterFunc, CallbackFunc]
+Hooks = Dict[int, FilterCallbackBundle]
+
+class Analyser():
+    """Analyser base class"""
+    def __init__(self, stream: Iterable[Event]):
+        self.stream: Iterator[Event] = iter(stream)
+        self.hooks: Hooks = {}
+        self.init()
+
+    def init(self):
+        """Subclasses override this method to set up for their particular use case"""
+
+    def add_event_hook(self, filter_fn: FilterFunc, callback: CallbackFunc) -> int:
+        """Adds an event hook that watches for certain types of events and calls a callback function on them"""
+        filter_id = id(filter_fn)
+        self.hooks[filter_id] = (filter_fn, callback)
+        return filter_id
+
+    def remove_event_hook(self, filter_id: int):
+        """Removes an event hook"""
+        del self.hooks[filter_id]
+
+    def process_events(self):
+        """The 'main' loop. Grabs every event, and calls all relevant callback functions on them"""
+        for event in self.stream:
+            for filter_fn, callback in self.hooks.values():
+                if filter_fn(event):
+                    callback(event)
+
+        return self.results()
+
+    def results(self) -> Any:
+        """Override to provide results from your analyzer. It's up to you to return what you want"""


### PR DESCRIPTION
* Add an 'Analyser' class that allows you to hook the event stream and run certain higher-level parsing activities. This is separate from the concept of a Normaliser because Normalisers can also pass events through, and the purpose of Analysers is to process that data rather than normalize/transmit that data
* Rewrite the cli default representation to use an implementation of an analyser both to show a good example and because it reduces bloat in `client.py` anyway