### PR TITLE
Allow writers to clean up their mess

### DIFF
--- a/nari/io/writer/__init__.py
+++ b/nari/io/writer/__init__.py
@@ -20,8 +20,12 @@ class Writer(metaclass=ABCMeta):
                 self.write_next(next_event)
                 index += 1
             except StopIteration:
+                self.cleanup()
                 return
 
     @abstractmethod
     def write_next(self, event: Event) -> None:
         """Implementing classes must implement this method to write the next event"""
+
+    def cleanup(self):
+        """Override to provide any cleanup items you need to do after the last item was written"""


### PR DESCRIPTION
Really, this fix is needed to address a bug in naritai's db writer, but it adds an override-able 'cleanup' method that writers can use to perform any cleanup they need after the last item has been written (might not trigger in batch mode)