### PR TITLE
Docs pass

### DIFF
--- a/nari/io/reader/actlogutils/ability.py
+++ b/nari/io/reader/actlogutils/ability.py
@@ -38,9 +38,9 @@ def ability_from_logline(timestamp: datetime, params: List[str]) -> Event:
     |5    |string|Target actor name|
     |6-21 |ActionEffect(s)|Every two fields make up 1 ActionEffect. See `action_effect_from_logline` for more info on parsing this.|
     |22   |int|Source current HP|
-    |23   |int|Source max MP|
-    |24   |int|Source current HP|
-    |25   |int|Source max HP|
+    |23   |int|Source max HP|
+    |24   |int|Source current MP|
+    |25   |int|Source max MP|
     |26   |int|Source current TP/others?|
     |27   |int|Source max TP/others?|
     |28   |float|Source actor X position|
@@ -48,9 +48,9 @@ def ability_from_logline(timestamp: datetime, params: List[str]) -> Event:
     |30   |float|Source actor Z position|
     |31   |float|Source actor facing|
     |32   |int|Target current HP|
-    |33   |int|Target max MP|
-    |34   |int|Target current HP|
-    |35   |int|Target max HP|
+    |33   |int|Target max HP|
+    |34   |int|Target current MP|
+    |35   |int|Target max MP|
     |36   |int|Target current TP/others?|
     |37   |int|Target max TP/others?|
     |38   |float|Target actor X position|

--- a/nari/io/reader/actlogutils/ability.py
+++ b/nari/io/reader/actlogutils/ability.py
@@ -31,11 +31,11 @@ def ability_from_logline(timestamp: datetime, params: List[str]) -> Event:
     |Index|Type|Description|
     |----:|----|:----------|
     |0    |int|Source actor ID|
-    |1    |string|Source actor Name|
+    |1    |string|Source actor name|
     |2    |int|Ability ID|
     |3    |string|Ability name|
     |4    |int|Target actor ID|
-    |5    |string|Target actor Name|
+    |5    |string|Target actor name|
     |6-21 |ActionEffect(s)|Every two fields make up 1 ActionEffect. See `action_effect_from_logline` for more info on parsing this.|
     |22   |int|Source current HP|
     |23   |int|Source max MP|

--- a/nari/io/reader/actlogutils/ability.py
+++ b/nari/io/reader/actlogutils/ability.py
@@ -30,12 +30,12 @@ def ability_from_logline(timestamp: datetime, params: List[str]) -> Event:
 
     |Index|Type|Description|
     |----:|----|:----------|
-    |0    |int|Source Actor ID|
-    |1    |string|Source Actor Name|
-    |2    |int|Ability id|
-    |3    |string|ability name|
-    |4    |int|Target Actor ID|
-    |5    |string|Target Actor Name|
+    |0    |int|Source actor ID|
+    |1    |string|Source actor Name|
+    |2    |int|Ability ID|
+    |3    |string|Ability name|
+    |4    |int|Target actor ID|
+    |5    |string|Target actor Name|
     |6-21 |ActionEffect(s)|Every two fields make up 1 ActionEffect. See `action_effect_from_logline` for more info on parsing this.|
     |22   |int|Source current HP|
     |23   |int|Source max MP|
@@ -60,20 +60,6 @@ def ability_from_logline(timestamp: datetime, params: List[str]) -> Event:
     |42   |int|Sequence ID|
 
     """
-    # param layout from act
-    # 0-1 source actor id/name
-    # 2-3 ability id/name
-    # 4-5 target actor id/name
-    # 6-21 ActionEffect(s) (every 2 fields is 1 ActionEffect)
-    # 22-23 source current/max hp
-    # 24-25 source current/max mp
-    # 26-27 source current/max tp/others?
-    # 28-31 source actor x/y/z/facing
-    # 32-33 target current/max hp
-    # 34-35 target current/max mp
-    # 36-37 target current/max tp/others?
-    # 38-41 target actor x/y/z/facing
-    # 42 globalsequence
     source_actor = Actor(*params[0:2])
     ability = AbilityType(*params[2:4])
     target_actor = Actor(*params[4:6])

--- a/nari/io/reader/actlogutils/actorspawn.py
+++ b/nari/io/reader/actlogutils/actorspawn.py
@@ -18,7 +18,7 @@ def actor_spawn_from_logline(timestamp: datetime, params: List[str]) -> Event:
     |Index|Type|Description|
     |----:|----|:----------|
     |0    |int|Source actor ID|
-    |1    |string|Source actor Name|
+    |1    |string|Source actor name|
     |2    |int|Source current HP|
     |3    |int|Source max HP|
     |4    |int|Source current MP|
@@ -29,7 +29,7 @@ def actor_spawn_from_logline(timestamp: datetime, params: List[str]) -> Event:
     |9    |float|Source actor Y position|
     |10   |float|Source actor Z position|
     |11   |float|Source actor facing|
-    
+
     """
     source_actor = Actor(*params[0:2])
     try:

--- a/nari/io/reader/actlogutils/actorspawn.py
+++ b/nari/io/reader/actlogutils/actorspawn.py
@@ -7,13 +7,30 @@ from nari.types.event import Event
 from nari.types.event.actorspawn import ActorSpawn
 
 def actor_spawn_from_logline(timestamp: datetime, params: List[str]) -> Event:
-    """Helper function to parse spawn data from act log line"""
-    # param layout from act
-    # 0-1 actor id/name
-    # 2-3 source current/max hp
-    # 4-5 source current/max mp
-    # 6-7 source current/max tp/others?
-    # 8-11 source actor x/y/z/facing
+    """Returns an actor spawn event from an act logline
+
+    ACT Event ID (decimal): 
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Source actor ID|
+    |1    |string|Source actor Name|
+    |2    |int|Source current HP|
+    |3    |int|Source max HP|
+    |4    |int|Source current MP|
+    |5    |int|Source max MP|
+    |6    |int|Source current TP/others?|
+    |7    |int|Source max TP/others?|
+    |8    |float|Source actor X position|
+    |9    |float|Source actor Y position|
+    |10   |float|Source actor Z position|
+    |11   |float|Source actor facing|
+    
+    """
     source_actor = Actor(*params[0:2])
     try:
         source_actor.resources.update(

--- a/nari/io/reader/actlogutils/cast.py
+++ b/nari/io/reader/actlogutils/cast.py
@@ -26,7 +26,7 @@ def startcast_from_logline(timestamp: datetime, params: List[str]) -> Event:
     |4    |int|Target actor ID|
     |5    |string|Target actor name|
     |6    |float|Duration?|
-    |7    |int|Blank field?|
+    |7    |string|Blank field?|
 
     """
     source_actor = Actor(*params[0:2])

--- a/nari/io/reader/actlogutils/cast.py
+++ b/nari/io/reader/actlogutils/cast.py
@@ -20,14 +20,14 @@ def startcast_from_logline(timestamp: datetime, params: List[str]) -> Event:
     |Index|Type|Description|
     |----:|----|:----------|
     |0    |int|Source actor ID|
-    |1    |string|Source actor Name|
+    |1    |string|Source actor name|
     |2    |int|Ability ID|
     |3    |string|Ability name|
     |4    |int|Target actor ID|
-    |5    |string|Target actor Name|
+    |5    |string|Target actor name|
     |6    |float|Duration?|
     |7    |int|Blank field?|
-    
+
     """
     source_actor = Actor(*params[0:2])
     ability = AbilityType(*params[2:4])

--- a/nari/io/reader/actlogutils/cast.py
+++ b/nari/io/reader/actlogutils/cast.py
@@ -9,13 +9,26 @@ from nari.types.event.startcast import StartCast
 from nari.types.event.stopcast import StopCast, StopCastType
 
 def startcast_from_logline(timestamp: datetime, params: List[str]) -> Event:
-    """Parses start cast event from act log line"""
-    # param layout from act
-    # 0-1 Source Actor
-    # 2-3 Ability
-    # 4-5 Target Actor
-    # 6 duration ???
-    # 7 blank field ???
+    """Parses a start cast event from an act log line
+
+    ACT Event ID (decimal): 20
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Source actor ID|
+    |1    |string|Source actor Name|
+    |2    |int|Ability ID|
+    |3    |string|Ability name|
+    |4    |int|Target actor ID|
+    |5    |string|Target actor Name|
+    |6    |float|Duration?|
+    |7    |int|Blank field?|
+    
+    """
     source_actor = Actor(*params[0:2])
     ability = AbilityType(*params[2:4])
     target_actor = Actor(*params[4:6])

--- a/nari/io/reader/actlogutils/death.py
+++ b/nari/io/reader/actlogutils/death.py
@@ -7,11 +7,22 @@ from nari.types.event import Event
 from nari.types.event.death import Death
 
 def death_from_logline(timestamp: datetime, params: List[str]) -> Event:
-    """Helper function to parse death information from act log line"""
-    # param layout from act
-    # 0-1 - 'target actor' (the thing that died)
-    # 2-3 - 'source actor' (the thing that did the killing)
-    # 3 can be blank because 2 might be 'E0000000' (no actor)
+    """Parses a death event from an act log line
+
+    ACT Event ID (decimal): 25
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Target actor ID - The thing that died.|
+    |1    |string|Target actor name|
+    |2    |int|Source actor ID - The thing that did the killing.|
+    |3    |string|Source actor name - This field will be blank if field 2 is 'E0000000' (no actor).|
+    
+    """
     target_actor = Actor(*params[0:2])
     source_actor = Actor(*params[2:4])
     return Death(timestamp=timestamp, source_actor=source_actor, target_actor=target_actor)

--- a/nari/io/reader/actlogutils/directorupdate.py
+++ b/nari/io/reader/actlogutils/directorupdate.py
@@ -9,14 +9,23 @@ from nari.types.event.instance import InstanceComplete, InstanceFade, InstanceIn
 from nari.types.director import DirectorUpdateCommand
 
 def director_events_from_logline(timestamp: datetime, params: List[str]) -> Optional[Event]:
-    """Helper function to parse director events from act log lines"""
-    # Param layout from act:
-    # 0 - first 2 bytes are from category, second 2 bytes is instance_id
-    # 1 - director 'command'
-    # 2-N - depends on the command
-    #
-    # Basically, we're going to return one of BarrierToggle, InstanceComplete,
-    # InstanceVote, InstanceFade, or InstanceInit from this event
+    """Parses a director event from an act log line
+
+    ACT Event ID (decimal): 33
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    This event will be one of `BarrierToggle`, `InstanceComplete`, `InstanceVote`, `InstanceFade`, or `InstanceInit`.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|The first two bytes are from the category, and the second two bytes make up the instance ID.|
+    |1    |int|The director command ID.|
+    |2-N  ||Depends on the command.|
+    
+    """
     # category = int(params[0][:4], 16)
     instance_id = int(params[0][:4], 16)
     command = int(params[1], 16)

--- a/nari/io/reader/actlogutils/effectresult.py
+++ b/nari/io/reader/actlogutils/effectresult.py
@@ -8,25 +8,45 @@ from nari.types.actor import Actor
 from nari.types.event.effectresult import EffectResult, EffectResultEntry
 
 def effectresult_from_logline(timestamp: datetime, params: List[str]) -> Event:
-    """Helper function to parse effect result data from act log line"""
-    # param layout from act
-    # 0-1 Actor ID/Name
-    # 2 Sequence ID (uint32)
-    # 3-4 Actor HP/Max HP
-    # 5-6 Actor MP/Max MP
-    # 7 Shield (uint8)
-    # 8 Blank?
-    # 9-12 X/Y/Z/Facing
-    # 13 unknown
-    # 14 unknown
-    # 15 unknown
-    # 16 effect result entry count
-    # 17-(N-1) Effect Result Entries (up to 4 groups, meaning N <= 29)
-    # These have the following 4 fields in order
-    #     1. BBH -> EffectIndex / Padding / EffectId
-    #     2. II -> padding / some kind of param
-    #     3. effect duration (float as hex)
-    #     4. source actor id
+    """Returns an effect result event from an act log line
+
+    ACT Event ID (decimal): 37
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Actor ID|
+    |1    |string|Actor name|
+    |2    |uint32|Sequence ID|
+    |3    |int|Actor current HP|
+    |4    |int|Actor max HP|
+    |5    |int|Actor current MP|
+    |6    |int|Actor max MP|
+    |7    |uint8|Shield|
+    |8    |string|Blank field?|
+    |9    |float|Actor X position|
+    |10   |float|Actor Y position|
+    |11   |float|Actor Z position|
+    |12   |float|Actor facing|
+    |13   |int|Unknown|
+    |14   |int|Unknown|
+    |15   |int|Unknown|
+    |16   |int|EffectResult entry count|
+    |17-N |EffectResult(s)|Every four fields makes up one EffectResult entry, and there are up to four groups, meaning N <= 29.|
+
+    Each EffectResult entry has the following four fields, in order:
+    
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|BBH -> EffectIndex / Padding / EffectId|
+    |1    |int|II -> padding / some kind of param|
+    |2    |float|Effect duration (as hex)|
+    |3    |int|Source actor ID|
+
+    """
     target_actor = Actor(*params[0:2])
     sequence_id = int(params[2], 16)
     try:

--- a/nari/io/reader/actlogutils/gauge.py
+++ b/nari/io/reader/actlogutils/gauge.py
@@ -7,11 +7,20 @@ from nari.util.byte import hexstr_to_bytes
 from nari.util.exceptions import ActLineReadError
 
 def gauge_from_logline(timestamp: datetime, params: List[str]) -> Gauge:
-    """Parses gauge event out from act log line"""
-    # Param layout from ACT
-    # 0 - 'actor id' which is the player who is logging.
-    # 1-4 - Gauge data is from a C-style union type stored with fields depending on job. ACT represents this as four
-    #       32-bit unsigned ints so they're left as bytes for destructuring later.
+    """Parses a gauge event from an act log line
+
+    ACT Event ID (decimal): 31
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Actor ID - The player who is logging.|
+    |1-4  |uint32|Gauge data is from a C-style union type stored with fields depending on job. ACT represents this as four 32-bit unsigned ints so they're left as bytes for destructuring later.|
+    
+    """
 
     try:
         actor_id = int(params[0], 16)

--- a/nari/io/reader/actlogutils/limitbreak.py
+++ b/nari/io/reader/actlogutils/limitbreak.py
@@ -7,10 +7,20 @@ from nari.types.event import Event
 from nari.types.event.limitbreak import LimitBreak
 
 def limitbreak_from_logline(timestamp: datetime, params: List[str]) -> Event:
-    """Helper function to parse limit break"""
-    # param layout from act
-    # 0 - bar amount; 10,000 = 1 full bar
-    # 1 - number of bars (3 for 3 full limit bars)
+    """Parses a limit break event from an act log line
+
+    ACT Event ID (decimal): 36
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Bar amount; 10,000 = 1 full bar.|
+    |1    |int|Number of bars (3 for 3 full limit bars).|
+    
+    """
     amount = int(params[0], 16)
     bars = int(params[1])
     return LimitBreak(

--- a/nari/io/reader/actlogutils/party.py
+++ b/nari/io/reader/actlogutils/party.py
@@ -7,13 +7,20 @@ from nari.types.event.party import PartyList
 
 
 def partylist_from_logline(timestamp: datetime, params: List[str]) -> Optional[Event]:
-    """Parses a partylist event out from act log line"""
-    # Param layout from ACT
-    # 0 - number of actor IDs
-    # 1 - 0 or more actor IDs for the party. First entry is always your actor;
-    #     subsequent actors are those of your party (up to the amount listed
-    #     in param 0). Any further actors are actors that are a part of your
-    #     alliance
+    """Parses a PartyList event from an act log line
+
+    ACT Event ID (decimal): 11
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Number of actor IDs|
+    |1    |int|Zero or more actor IDs for the party. First entry is always your actor; subsequent actors are those of your party (up to the amount listed in param 0). Any further actors are actors that are a part of your alliance.|
+    
+    """
     amount = int(params[0])
     if amount == 0:
         return None

--- a/nari/io/reader/actlogutils/playerstats.py
+++ b/nari/io/reader/actlogutils/playerstats.py
@@ -9,28 +9,36 @@ from nari.util.exceptions import ActLineReadError
 
 
 def playerstats_from_logline(timestamp: datetime, params: List[str]) -> PlayerStats:
-    """Parses playerstats event from logline.
+    """Parses a PlayerStats event from an act log line
+
+    ACT Event ID (decimal): 12
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
     Param 15 is blank so it is parsed out.
 
-    Format is as follows:
-
-    0: JOB
-    1: STR
-    2: DEX
-    3: VIT
-    4: INT
-    5: MND
-    6: PIE
-    7: ATTACK POWER
-    8: DHIT
-    9: CRIT
-    10: ATTACK MAGIC POTENCY
-    11: HEAL MAGIC POTENCY
-    12: DET
-    13: SKILL SPEED
-    14: SPELL SPEED
-    15: Blank (0)
-    16: TENACITY
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Class/Job ID|
+    |1    |int|Strength|
+    |2    |int|Dexterity|
+    |3    |int|Vitality|
+    |4    |int|Intelligence|
+    |5    |int|Mind|
+    |6    |int|Piety|
+    |7    |int|Attack power|
+    |8    |int|Direct hit|
+    |9    |int|Critical hit|
+    |10   |int|Attack magic potency|
+    |11   |int|Heal magic potency|
+    |12   |int|Determination|
+    |13   |int|Skill speed|
+    |14   |int|Spell speed|
+    |15   |int|Blank (0)|
+    |16   |int|Tenacity|
+    
     """
 
     param_order: List[Stats] = [

--- a/nari/io/reader/actlogutils/status.py
+++ b/nari/io/reader/actlogutils/status.py
@@ -46,15 +46,32 @@ def status_effect_from_logline(param0, param1, param2):
     )
 
 def statuslist_from_logline(timestamp: datetime, params: List[str]) -> Event:
-    """Parse statuslist from a logline"""
-    # param layout from act
-    # 0-1 - target actor id/name
-    # 2 - classjoblevel data
-    # 3-4 - hp / hp max
-    # 5-6 - mp / mp max
-    # 7-8 - tp / tp max
-    # 9-12 - x/y/z/facing
-    # 13- - status effect list, in sets of 3
+    """Parses a StatusList event from an act log line
+
+    ACT Event ID (decimal): 38
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Target actor ID|
+    |1    |string|Target actor name|
+    |2    |ClassJobLevel|Target actor ClassJob level|
+    |3    |int|Target current HP|
+    |4    |int|Target max HP|
+    |5    |int|Target current MP|
+    |6    |int|Target max MP|
+    |7    |int|Target current TP/others?|
+    |8    |int|Target max TP/others?|
+    |9    |float|Target actor X position|
+    |10   |float|Target actor Y position|
+    |11   |float|Target actor Z position|
+    |12   |float|Target actor facing|
+    |13-N |StatusEffect(s)|List of StatusEffects, in sets of 3|
+    
+    """
     target_actor = Actor(*params[0:2])
     class_job_level = classjoblevel_from_logline(params[2])
     target_actor.resources.update(

--- a/nari/io/reader/actlogutils/status.py
+++ b/nari/io/reader/actlogutils/status.py
@@ -63,8 +63,8 @@ def statuslist_from_logline(timestamp: datetime, params: List[str]) -> Event:
     |4    |int|Target max HP|
     |5    |int|Target current MP|
     |6    |int|Target max MP|
-    |7    |int|Target current TP/others?|
-    |8    |int|Target max TP/others?|
+    |7    |int|Target current TP|
+    |8    |int|Target max TP|
     |9    |float|Target actor X position|
     |10   |float|Target actor Y position|
     |11   |float|Target actor Z position|

--- a/nari/io/reader/actlogutils/updatehp.py
+++ b/nari/io/reader/actlogutils/updatehp.py
@@ -7,15 +7,31 @@ from nari.types.event.updatehpmp import UpdateHpMp
 from nari.types.actor import Actor
 
 def updatehp_from_logline(timestamp: datetime, params: List[str]) -> UpdateHpMp:
-    """Helper function to parse hp data from act log data"""
-    # Param layout from act:
-    # 0-1 - Actor ID/Name
-    # 2-3 - hp/max hp
-    # 4-5 - mp/max mp
-    # 6-7 - tp/max tp
-    # 8-11 - x/y/z/facing
-    # 12 - blank because ACT
+    """Parses an UpdateHpMp event from an act log line
 
+    ACT Event ID (decimal): 39
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Actor ID|
+    |1    |string|Actor name|
+    |2    |int|Current HP|
+    |3    |int|Max HP|
+    |4    |int|Current MP|
+    |5    |int|Max MP|
+    |6    |int|Current TP|
+    |7    |int|Max TP|
+    |8    |float|Actor X position|
+    |9    |float|Actor Y position|
+    |10   |float|Actor Z position|
+    |11   |float|Actor facing|
+    |12   |string|Blank because ACT|
+    
+    """
     actor = Actor(*params[0:2])
     try:
         actor.resources.update(

--- a/nari/io/reader/actlogutils/visibility.py
+++ b/nari/io/reader/actlogutils/visibility.py
@@ -8,11 +8,23 @@ from nari.types.event import Event
 from nari.types.event.visibility import VisibilityChange, VisibilityState, VisibilityType
 
 def visibility_from_logline(timestamp: datetime, params: List[str]) -> Event:
-    """Parses networknametoggle from act log line"""
-    # param layout from act
-    # 0-1 source actor name/id
-    # 2-3 target actor name/id
-    # 4 0 for invisible, 1 for visible
+    """Parses a VisibilityChange event from an act log line
+
+    ACT Event ID (decimal): 34
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Source actor ID|
+    |1    |string|Source actor name|
+    |2    |int|Target actor ID|
+    |3    |string|Target actor name|
+    |4    |int|0 for invisible, 1 for visible|
+    
+    """
     actor = Actor(*params[0:2])
     visibility = VisibilityState(int(params[4]))
     return VisibilityChange(

--- a/nari/io/reader/actlogutils/zone.py
+++ b/nari/io/reader/actlogutils/zone.py
@@ -7,7 +7,20 @@ from nari.types.event import Event
 from nari.types.event.zone import ZoneChange
 
 def zonechange_from_logline(timestamp: datetime, params: List[str]) -> Event:
-    """Helper function to parse zone information from act log line"""
+    """Parses a ZoneChange event from an act log line
+
+    ACT Event ID (decimal): 1
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Zone ID|
+    |1    |string|Zone name|
+    
+    """
     # param layout from act
     # 0 - zone id
     # 1 - zone name

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open('README.md', 'r') as f:
+with open('README.md', 'r', encoding='utf-8') as f:
     long_description = f.read()
 
 dev_requirements = [


### PR DESCRIPTION
**Purpose**
Adding docstrings to nari.io.reader.actlogutils according to the draft format.

**New Features**
https://github.com/xivlogs/nari/pull/51

**Additional Context**
I didn't see an event ID for ActorSpawn, so I left that blank for now. For EffectResult, there was more information on the entries than would fit nicely in the standard table, so I added a second table after the main event documentation.